### PR TITLE
Left tree structure optimization

### DIFF
--- a/frontend/src/components/DatabaseListSidePanel.vue
+++ b/frontend/src/components/DatabaseListSidePanel.vue
@@ -96,12 +96,14 @@ const databaseListByEnvironment = computed(() => {
   list.sort((a: any, b: any) => {
     return a.name.localeCompare(b.name);
   });
+  const databaseEntityTitle: string[] = [];
   for (const database of list) {
     const dbList = envToDbMap.get(
       String(database.instanceEntity.environmentEntity.uid)
     )!;
     // dbList may be undefined if the environment is archived
     if (dbList) {
+      databaseEntityTitle.push(`${database.instanceEntity.title}`);
       dbList.push({
         id: `bb.database.${database.uid}`,
         name: `${database.databaseName} (${database.instanceEntity.title})`,
@@ -119,12 +121,33 @@ const databaseListByEnvironment = computed(() => {
       return {
         id: `bb.env.${environment.uid}`,
         name: environmentV1Name(environment),
-        childList: envToDbMap.get(environment.uid),
+        // childList: envToDbMap.get(environment.uid),
+        childList: databaseMenuList(envToDbMap.get(environment.uid), databaseEntityTitle),
         childCollapse: true,
       };
     });
 });
 
+const databaseMenuList = (props: any, title: any) => {
+  const regex = /\((.+?)\)/g;
+  const titleSet = [...new Set(title)];
+  const arr: any[] = [];
+  titleSet.map((title: any) => {
+    arr.push({
+      id: `bb.example.${title}`,
+      name: title,
+      childList: props.filter((item: any) => {
+        const itemTitle = item.name.match(regex)[0].replace("(","").replace(")","");
+        return itemTitle === title
+      }),
+      childCollapse: true,
+    })
+  })
+  return arr.filter(child => {
+    return child.childList.length > 0
+  });
+}
+  
 const tenantDatabaseListByProject = computed((): BBOutlineItem[] => {
   const dbList = databaseList.value.filter(
     (db) => db.projectEntity.tenantMode === TenantMode.TENANT_MODE_ENABLED


### PR DESCRIPTION
At present, our scenario is that there are a large number of similar database instances, for example, there are 10 database instances, and there are aaa and bbb databases in each instance. According to the current GUI interface, there will be 10 aaa \ bbb databases with the same name displayed on the left, and it is impossible to determine which database belongs to which instance.

Therefore, I hope to optimize the tree structure on the left: change the current second-level directory to third-level  (environment---database instance---included database)

thanks！

the issue is [https://github.com/bytebase/bytebase/issues/6747](url)